### PR TITLE
GitHub: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @wooksong
+* @again4you @juseful @Juyounge-e @petanerd @sangwoolee392 @wooksong @Yennyx


### PR DESCRIPTION
This PR adds the study members' GitHub accounts to CODEOWNERS.